### PR TITLE
#3 API actions rate limiting

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -64,3 +64,19 @@ POSTGRES_MIGRATIONS_PATH=
 # Description:
 #  Whether to run app-driver migrations on start
 POSTGRES_DO_MIGRATE=false
+
+#############################
+# Rate limits configuration
+#############################
+
+POSTS_LIMIT=30
+
+# Description:
+#  https://pkg.go.dev/time#ParseDuration
+POSTS_PERIOD=1h
+
+COMMENTS_LIMIT=100
+
+# Description:
+#  https://pkg.go.dev/time#ParseDuration
+COMMENTS_PERIOD=30m

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ godoc:
 # Generate go app swagger documentation
 swag:
 	swag fmt
-	swag init --ot go,json --parseInternal -g ./cmd/workshop/main.go
+	swag init --ot go,json --parseDependency --parseInternal -g ./cmd/workshop/main.go
 
 
 ###########################

--- a/cmd/workshop/main.go
+++ b/cmd/workshop/main.go
@@ -5,6 +5,8 @@ import (
 	"github.com/rs/zerolog/log"
 	_ "workshop/docs"
 	"workshop/internal/app"
+	_ "workshop/internal/controller"
+	_ "workshop/internal/controller/echo"
 )
 
 // @title						Workshop Service

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -39,6 +39,18 @@ const docTemplate = `{
                 "summary": "Get Comments",
                 "parameters": [
                     {
+                        "type": "integer",
+                        "description": "Post ID",
+                        "name": "postID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Author ID",
+                        "name": "authorID",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "asc",
                             "desc"
@@ -73,20 +85,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/workshop.Comment"
+                                "$ref": "#/definitions/workshop_internal_service_workshop.Comment"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -118,7 +130,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.AddCommentRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.AddCommentRequest"
                         }
                     }
                 ],
@@ -126,31 +138,37 @@ const docTemplate = `{
                     "200": {
                         "description": "Comment created successfully",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Comment"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Comment"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient user rights",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – associated post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
+                        }
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded",
+                        "schema": {
+                            "$ref": "#/definitions/workshop_internal_controller.APIGenericError-workshop_internal_controller_APIRateLimitErrorData"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -191,7 +209,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.UpdateCommentRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.UpdateCommentRequest"
                         }
                     }
                 ],
@@ -199,31 +217,31 @@ const docTemplate = `{
                     "200": {
                         "description": "Comment updated successfully",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Comment"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Comment"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient user rights",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – comment not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -264,25 +282,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient user rights",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – comment not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -310,6 +328,18 @@ const docTemplate = `{
                 ],
                 "summary": "Get Moderation Actions",
                 "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Post ID",
+                        "name": "postID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Moderator ID",
+                        "name": "moderatorID",
+                        "in": "query"
+                    },
                     {
                         "enum": [
                             "approve",
@@ -355,26 +385,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/workshop.ModerationAction"
+                                "$ref": "#/definitions/workshop_internal_service_workshop.ModerationAction"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – caller lacks post moderator permissions",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -410,6 +440,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Author ID",
+                        "name": "author_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "boolean",
                         "description": "Filter to include only approved posts",
                         "name": "only_approved",
@@ -419,6 +455,12 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Filter to include declined posts. Requires 'POST_MODERATOR' role.",
                         "name": "show_declined",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Post type. Valid values should be enforced by server-side validation.",
+                        "name": "type",
                         "in": "query"
                     },
                     {
@@ -505,26 +547,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/workshop.Post"
+                                "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid filter parameters or conflicting filter options",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions for specified filters",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -556,7 +598,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.CreatePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.CreatePostRequest"
                         }
                     }
                 ],
@@ -564,31 +606,31 @@ const docTemplate = `{
                     "201": {
                         "description": "Newly created post",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input data",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions to create posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "429": {
-                        "description": "Too Many Requests – post creation limit exceeded",
+                        "description": "Rate limit exceeded",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIGenericError-workshop_internal_controller_APIRateLimitErrorData"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -634,31 +676,31 @@ const docTemplate = `{
                     "200": {
                         "description": "Post details",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid parameters",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions for specified filters",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -697,7 +739,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.UpdatePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.UpdatePostRequest"
                         }
                     }
                 ],
@@ -705,37 +747,37 @@ const docTemplate = `{
                     "200": {
                         "description": "Updated post details",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input data",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions to update posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "412": {
                         "description": "Precondition Failed – the post is not owned by the user",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -774,7 +816,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.DeletePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.DeletePostRequest"
                         }
                     }
                 ],
@@ -785,31 +827,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request – invalid input data",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions to delete posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "412": {
                         "description": "Precondition Failed – the post is not owned by the user",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -853,31 +895,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – only authorized users can favorite posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict – post is already in favorites",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -919,25 +961,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – only authorized users can unfavorite posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post is not marked as favorite or does not exist\"\t//\t(рекомендуемый статус: 412 Precondition Failed, если статус отличается)",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -979,7 +1021,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.ModeratePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.ModeratePostRequest"
                         }
                     }
                 ],
@@ -990,19 +1032,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request – invalid payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – caller lacks post moderator permissions",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -1037,7 +1079,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.RatePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.RatePostRequest"
                         }
                     }
                 ],
@@ -1048,31 +1090,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request – invalid input or payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – only authorized users can rate posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – the post was not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict – the post has already been rated by the user",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -1080,15 +1122,38 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "controller.APIError": {
+        "workshop_internal_controller.APIError": {
+            "type": "object",
+            "properties": {
+                "message": {}
+            }
+        },
+        "workshop_internal_controller.APIGenericError-workshop_internal_controller_APIRateLimitErrorData": {
             "type": "object",
             "properties": {
                 "message": {
+                    "type": "string",
+                    "x-order": "0"
+                },
+                "data": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/workshop_internal_controller.APIRateLimitErrorData"
+                        }
+                    ],
+                    "x-order": "1"
+                }
+            }
+        },
+        "workshop_internal_controller.APIRateLimitErrorData": {
+            "type": "object",
+            "properties": {
+                "reset_at": {
                     "type": "string"
                 }
             }
         },
-        "controller.AddCommentRequest": {
+        "workshop_internal_controller.AddCommentRequest": {
             "type": "object",
             "required": [
                 "content",
@@ -1105,7 +1170,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controller.CreatePostRequest": {
+        "workshop_internal_controller.CreatePostRequest": {
             "type": "object",
             "required": [
                 "contents",
@@ -1174,10 +1239,10 @@ const docTemplate = `{
                 }
             }
         },
-        "controller.DeletePostRequest": {
+        "workshop_internal_controller.DeletePostRequest": {
             "type": "object"
         },
-        "controller.ModeratePostRequest": {
+        "workshop_internal_controller.ModeratePostRequest": {
             "type": "object",
             "required": [
                 "action"
@@ -1190,7 +1255,7 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.ModerationActionType"
+                            "$ref": "#/definitions/workshop_internal_types.ModerationActionType"
                         }
                     ],
                     "x-order": "0"
@@ -1201,7 +1266,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controller.RateAction": {
+        "workshop_internal_controller.RateAction": {
             "type": "string",
             "enum": [
                 "upvote",
@@ -1214,7 +1279,7 @@ const docTemplate = `{
                 "RateActionRetract"
             ]
         },
-        "controller.RatePostRequest": {
+        "workshop_internal_controller.RatePostRequest": {
             "type": "object",
             "required": [
                 "rating"
@@ -1228,13 +1293,13 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/controller.RateAction"
+                            "$ref": "#/definitions/workshop_internal_controller.RateAction"
                         }
                     ]
                 }
             }
         },
-        "controller.UpdateCommentRequest": {
+        "workshop_internal_controller.UpdateCommentRequest": {
             "type": "object",
             "required": [
                 "content"
@@ -1247,7 +1312,7 @@ const docTemplate = `{
                 }
             }
         },
-        "controller.UpdatePostRequest": {
+        "workshop_internal_controller.UpdatePostRequest": {
             "type": "object",
             "required": [
                 "description",
@@ -1272,46 +1337,7 @@ const docTemplate = `{
                 }
             }
         },
-        "types.ModerationActionType": {
-            "type": "string",
-            "enum": [
-                "approve",
-                "decline"
-            ],
-            "x-enum-varnames": [
-                "ModerationActionTypeApprove",
-                "ModeratorActionTypeDecline"
-            ]
-        },
-        "types.ModerationStatus": {
-            "type": "string",
-            "enum": [
-                "approved",
-                "declined",
-                "pending"
-            ],
-            "x-enum-varnames": [
-                "ModerationStatusApproved",
-                "ModerationStatusDeclined",
-                "ModerationStatusPending"
-            ]
-        },
-        "types.RateType": {
-            "type": "string",
-            "enum": [
-                "upvoted",
-                "downvoted",
-                "voted",
-                "none"
-            ],
-            "x-enum-varnames": [
-                "RateTypeUpvoted",
-                "RateTypeDownvoted",
-                "RateTypeVoted",
-                "RateTypeNone"
-            ]
-        },
-        "workshop.Comment": {
+        "workshop_internal_service_workshop.Comment": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1340,7 +1366,7 @@ const docTemplate = `{
                 }
             }
         },
-        "workshop.ModerationAction": {
+        "workshop_internal_service_workshop.ModerationAction": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1350,7 +1376,7 @@ const docTemplate = `{
                 "post": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     ],
                     "x-order": "1"
@@ -1362,7 +1388,7 @@ const docTemplate = `{
                 "action": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.ModerationActionType"
+                            "$ref": "#/definitions/workshop_internal_types.ModerationActionType"
                         }
                     ],
                     "x-order": "3"
@@ -1377,7 +1403,7 @@ const docTemplate = `{
                 }
             }
         },
-        "workshop.Post": {
+        "workshop_internal_service_workshop.Post": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1391,7 +1417,7 @@ const docTemplate = `{
                 "interaction_data": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/workshop.PostInteractionData"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.PostInteractionData"
                         }
                     ],
                     "x-order": "10"
@@ -1430,7 +1456,7 @@ const docTemplate = `{
                 "contents": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/workshop.PostContent"
+                        "$ref": "#/definitions/workshop_internal_service_workshop.PostContent"
                     },
                     "x-order": "6"
                 },
@@ -1445,14 +1471,14 @@ const docTemplate = `{
                 "moderation_data": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/workshop.PostModerationData"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.PostModerationData"
                         }
                     ],
                     "x-order": "9"
                 }
             }
         },
-        "workshop.PostContent": {
+        "workshop_internal_service_workshop.PostContent": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1473,7 +1499,7 @@ const docTemplate = `{
                 }
             }
         },
-        "workshop.PostInteractionData": {
+        "workshop_internal_service_workshop.PostInteractionData": {
             "type": "object",
             "properties": {
                 "is_favorite": {
@@ -1483,20 +1509,20 @@ const docTemplate = `{
                 "vote": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.RateType"
+                            "$ref": "#/definitions/workshop_internal_types.RateType"
                         }
                     ],
                     "x-order": "1"
                 }
             }
         },
-        "workshop.PostModerationData": {
+        "workshop_internal_service_workshop.PostModerationData": {
             "type": "object",
             "properties": {
                 "status": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.ModerationStatus"
+                            "$ref": "#/definitions/workshop_internal_types.ModerationStatus"
                         }
                     ],
                     "x-order": "0"
@@ -1506,6 +1532,45 @@ const docTemplate = `{
                     "x-order": "1"
                 }
             }
+        },
+        "workshop_internal_types.ModerationActionType": {
+            "type": "string",
+            "enum": [
+                "approve",
+                "decline"
+            ],
+            "x-enum-varnames": [
+                "ModerationActionTypeApprove",
+                "ModeratorActionTypeDecline"
+            ]
+        },
+        "workshop_internal_types.ModerationStatus": {
+            "type": "string",
+            "enum": [
+                "approved",
+                "declined",
+                "pending"
+            ],
+            "x-enum-varnames": [
+                "ModerationStatusApproved",
+                "ModerationStatusDeclined",
+                "ModerationStatusPending"
+            ]
+        },
+        "workshop_internal_types.RateType": {
+            "type": "string",
+            "enum": [
+                "upvoted",
+                "downvoted",
+                "voted",
+                "none"
+            ],
+            "x-enum-varnames": [
+                "RateTypeUpvoted",
+                "RateTypeDownvoted",
+                "RateTypeVoted",
+                "RateTypeNone"
+            ]
         }
     },
     "securityDefinitions": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -32,6 +32,18 @@
                 "summary": "Get Comments",
                 "parameters": [
                     {
+                        "type": "integer",
+                        "description": "Post ID",
+                        "name": "postID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Author ID",
+                        "name": "authorID",
+                        "in": "query"
+                    },
+                    {
                         "enum": [
                             "asc",
                             "desc"
@@ -66,20 +78,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/workshop.Comment"
+                                "$ref": "#/definitions/workshop_internal_service_workshop.Comment"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -111,7 +123,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.AddCommentRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.AddCommentRequest"
                         }
                     }
                 ],
@@ -119,31 +131,37 @@
                     "200": {
                         "description": "Comment created successfully",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Comment"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Comment"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient user rights",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – associated post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
+                        }
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded",
+                        "schema": {
+                            "$ref": "#/definitions/workshop_internal_controller.APIGenericError-workshop_internal_controller_APIRateLimitErrorData"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -184,7 +202,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.UpdateCommentRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.UpdateCommentRequest"
                         }
                     }
                 ],
@@ -192,31 +210,31 @@
                     "200": {
                         "description": "Comment updated successfully",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Comment"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Comment"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient user rights",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – comment not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -257,25 +275,25 @@
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient user rights",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – comment not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -303,6 +321,18 @@
                 ],
                 "summary": "Get Moderation Actions",
                 "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Post ID",
+                        "name": "postID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Moderator ID",
+                        "name": "moderatorID",
+                        "in": "query"
+                    },
                     {
                         "enum": [
                             "approve",
@@ -348,26 +378,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/workshop.ModerationAction"
+                                "$ref": "#/definitions/workshop_internal_service_workshop.ModerationAction"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – caller lacks post moderator permissions",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -403,6 +433,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Author ID",
+                        "name": "author_id",
+                        "in": "query"
+                    },
+                    {
                         "type": "boolean",
                         "description": "Filter to include only approved posts",
                         "name": "only_approved",
@@ -412,6 +448,12 @@
                         "type": "boolean",
                         "description": "Filter to include declined posts. Requires 'POST_MODERATOR' role.",
                         "name": "show_declined",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Post type. Valid values should be enforced by server-side validation.",
+                        "name": "type",
                         "in": "query"
                     },
                     {
@@ -498,26 +540,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/workshop.Post"
+                                "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                             }
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid filter parameters or conflicting filter options",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions for specified filters",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -549,7 +591,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.CreatePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.CreatePostRequest"
                         }
                     }
                 ],
@@ -557,31 +599,31 @@
                     "201": {
                         "description": "Newly created post",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input data",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions to create posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "429": {
-                        "description": "Too Many Requests – post creation limit exceeded",
+                        "description": "Rate limit exceeded",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIGenericError-workshop_internal_controller_APIRateLimitErrorData"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -627,31 +669,31 @@
                     "200": {
                         "description": "Post details",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid parameters",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions for specified filters",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -690,7 +732,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.UpdatePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.UpdatePostRequest"
                         }
                     }
                 ],
@@ -698,37 +740,37 @@
                     "200": {
                         "description": "Updated post details",
                         "schema": {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     },
                     "400": {
                         "description": "Bad Request – invalid input data",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions to update posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "412": {
                         "description": "Precondition Failed – the post is not owned by the user",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -767,7 +809,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.DeletePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.DeletePostRequest"
                         }
                     }
                 ],
@@ -778,31 +820,31 @@
                     "400": {
                         "description": "Bad Request – invalid input data",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – insufficient permissions to delete posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "412": {
                         "description": "Precondition Failed – the post is not owned by the user",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -846,31 +888,31 @@
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – only authorized users can favorite posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict – post is already in favorites",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -912,25 +954,25 @@
                     "400": {
                         "description": "Bad Request – invalid input payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – only authorized users can unfavorite posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – post is not marked as favorite or does not exist\"\t//\t(рекомендуемый статус: 412 Precondition Failed, если статус отличается)",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -972,7 +1014,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.ModeratePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.ModeratePostRequest"
                         }
                     }
                 ],
@@ -983,19 +1025,19 @@
                     "400": {
                         "description": "Bad Request – invalid payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – caller lacks post moderator permissions",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -1030,7 +1072,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/controller.RatePostRequest"
+                            "$ref": "#/definitions/workshop_internal_controller.RatePostRequest"
                         }
                     }
                 ],
@@ -1041,31 +1083,31 @@
                     "400": {
                         "description": "Bad Request – invalid input or payload",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "403": {
                         "description": "Forbidden – only authorized users can rate posts",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "404": {
                         "description": "Not Found – the post was not found",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "409": {
                         "description": "Conflict – the post has already been rated by the user",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/controller.APIError"
+                            "$ref": "#/definitions/workshop_internal_controller.APIError"
                         }
                     }
                 }
@@ -1073,15 +1115,38 @@
         }
     },
     "definitions": {
-        "controller.APIError": {
+        "workshop_internal_controller.APIError": {
+            "type": "object",
+            "properties": {
+                "message": {}
+            }
+        },
+        "workshop_internal_controller.APIGenericError-workshop_internal_controller_APIRateLimitErrorData": {
             "type": "object",
             "properties": {
                 "message": {
+                    "type": "string",
+                    "x-order": "0"
+                },
+                "data": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/workshop_internal_controller.APIRateLimitErrorData"
+                        }
+                    ],
+                    "x-order": "1"
+                }
+            }
+        },
+        "workshop_internal_controller.APIRateLimitErrorData": {
+            "type": "object",
+            "properties": {
+                "reset_at": {
                     "type": "string"
                 }
             }
         },
-        "controller.AddCommentRequest": {
+        "workshop_internal_controller.AddCommentRequest": {
             "type": "object",
             "required": [
                 "content",
@@ -1098,7 +1163,7 @@
                 }
             }
         },
-        "controller.CreatePostRequest": {
+        "workshop_internal_controller.CreatePostRequest": {
             "type": "object",
             "required": [
                 "contents",
@@ -1167,10 +1232,10 @@
                 }
             }
         },
-        "controller.DeletePostRequest": {
+        "workshop_internal_controller.DeletePostRequest": {
             "type": "object"
         },
-        "controller.ModeratePostRequest": {
+        "workshop_internal_controller.ModeratePostRequest": {
             "type": "object",
             "required": [
                 "action"
@@ -1183,7 +1248,7 @@
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.ModerationActionType"
+                            "$ref": "#/definitions/workshop_internal_types.ModerationActionType"
                         }
                     ],
                     "x-order": "0"
@@ -1194,7 +1259,7 @@
                 }
             }
         },
-        "controller.RateAction": {
+        "workshop_internal_controller.RateAction": {
             "type": "string",
             "enum": [
                 "upvote",
@@ -1207,7 +1272,7 @@
                 "RateActionRetract"
             ]
         },
-        "controller.RatePostRequest": {
+        "workshop_internal_controller.RatePostRequest": {
             "type": "object",
             "required": [
                 "rating"
@@ -1221,13 +1286,13 @@
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/controller.RateAction"
+                            "$ref": "#/definitions/workshop_internal_controller.RateAction"
                         }
                     ]
                 }
             }
         },
-        "controller.UpdateCommentRequest": {
+        "workshop_internal_controller.UpdateCommentRequest": {
             "type": "object",
             "required": [
                 "content"
@@ -1240,7 +1305,7 @@
                 }
             }
         },
-        "controller.UpdatePostRequest": {
+        "workshop_internal_controller.UpdatePostRequest": {
             "type": "object",
             "required": [
                 "description",
@@ -1265,46 +1330,7 @@
                 }
             }
         },
-        "types.ModerationActionType": {
-            "type": "string",
-            "enum": [
-                "approve",
-                "decline"
-            ],
-            "x-enum-varnames": [
-                "ModerationActionTypeApprove",
-                "ModeratorActionTypeDecline"
-            ]
-        },
-        "types.ModerationStatus": {
-            "type": "string",
-            "enum": [
-                "approved",
-                "declined",
-                "pending"
-            ],
-            "x-enum-varnames": [
-                "ModerationStatusApproved",
-                "ModerationStatusDeclined",
-                "ModerationStatusPending"
-            ]
-        },
-        "types.RateType": {
-            "type": "string",
-            "enum": [
-                "upvoted",
-                "downvoted",
-                "voted",
-                "none"
-            ],
-            "x-enum-varnames": [
-                "RateTypeUpvoted",
-                "RateTypeDownvoted",
-                "RateTypeVoted",
-                "RateTypeNone"
-            ]
-        },
-        "workshop.Comment": {
+        "workshop_internal_service_workshop.Comment": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1333,7 +1359,7 @@
                 }
             }
         },
-        "workshop.ModerationAction": {
+        "workshop_internal_service_workshop.ModerationAction": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1343,7 +1369,7 @@
                 "post": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/workshop.Post"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.Post"
                         }
                     ],
                     "x-order": "1"
@@ -1355,7 +1381,7 @@
                 "action": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.ModerationActionType"
+                            "$ref": "#/definitions/workshop_internal_types.ModerationActionType"
                         }
                     ],
                     "x-order": "3"
@@ -1370,7 +1396,7 @@
                 }
             }
         },
-        "workshop.Post": {
+        "workshop_internal_service_workshop.Post": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1384,7 +1410,7 @@
                 "interaction_data": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/workshop.PostInteractionData"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.PostInteractionData"
                         }
                     ],
                     "x-order": "10"
@@ -1423,7 +1449,7 @@
                 "contents": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/workshop.PostContent"
+                        "$ref": "#/definitions/workshop_internal_service_workshop.PostContent"
                     },
                     "x-order": "6"
                 },
@@ -1438,14 +1464,14 @@
                 "moderation_data": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/workshop.PostModerationData"
+                            "$ref": "#/definitions/workshop_internal_service_workshop.PostModerationData"
                         }
                     ],
                     "x-order": "9"
                 }
             }
         },
-        "workshop.PostContent": {
+        "workshop_internal_service_workshop.PostContent": {
             "type": "object",
             "properties": {
                 "id": {
@@ -1466,7 +1492,7 @@
                 }
             }
         },
-        "workshop.PostInteractionData": {
+        "workshop_internal_service_workshop.PostInteractionData": {
             "type": "object",
             "properties": {
                 "is_favorite": {
@@ -1476,20 +1502,20 @@
                 "vote": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.RateType"
+                            "$ref": "#/definitions/workshop_internal_types.RateType"
                         }
                     ],
                     "x-order": "1"
                 }
             }
         },
-        "workshop.PostModerationData": {
+        "workshop_internal_service_workshop.PostModerationData": {
             "type": "object",
             "properties": {
                 "status": {
                     "allOf": [
                         {
-                            "$ref": "#/definitions/types.ModerationStatus"
+                            "$ref": "#/definitions/workshop_internal_types.ModerationStatus"
                         }
                     ],
                     "x-order": "0"
@@ -1499,6 +1525,45 @@
                     "x-order": "1"
                 }
             }
+        },
+        "workshop_internal_types.ModerationActionType": {
+            "type": "string",
+            "enum": [
+                "approve",
+                "decline"
+            ],
+            "x-enum-varnames": [
+                "ModerationActionTypeApprove",
+                "ModeratorActionTypeDecline"
+            ]
+        },
+        "workshop_internal_types.ModerationStatus": {
+            "type": "string",
+            "enum": [
+                "approved",
+                "declined",
+                "pending"
+            ],
+            "x-enum-varnames": [
+                "ModerationStatusApproved",
+                "ModerationStatusDeclined",
+                "ModerationStatusPending"
+            ]
+        },
+        "workshop_internal_types.RateType": {
+            "type": "string",
+            "enum": [
+                "upvoted",
+                "downvoted",
+                "voted",
+                "none"
+            ],
+            "x-enum-varnames": [
+                "RateTypeUpvoted",
+                "RateTypeDownvoted",
+                "RateTypeVoted",
+                "RateTypeNone"
+            ]
         }
     },
     "securityDefinitions": {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/Jagerente/gocfg v1.0.3
+	github.com/alicebob/miniredis/v2 v2.34.0
 	github.com/go-playground/validator/v10 v10.24.0
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/labstack/echo/v4 v4.13.3
@@ -18,6 +19,7 @@ require (
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -49,6 +51,7 @@ require (
 	github.com/swaggo/files/v2 v2.0.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/net v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=
+github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/miniredis/v2 v2.34.0 h1:mBFWMaJSNL9RwdGRyEDoAAv8OQc5UlEhLDQggTglU/0=
+github.com/alicebob/miniredis/v2 v2.34.0/go.mod h1:kWShP4b58T1CW0Y5dViCd5ztzrDqRWqM3nksiyXk5s8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -30,8 +34,6 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
-github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -54,8 +56,6 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.23.0 h1:/PwmTwZhS0dPkav3cdK9kV1FsAmrL8sThn8IHr/sO+o=
-github.com/go-playground/validator/v10 v10.23.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-playground/validator/v10 v10.24.0 h1:KHQckvo8G6hlWnrPX4NJJ+aBfWNAE/HH+qdL2cBpCmg=
 github.com/go-playground/validator/v10 v10.24.0/go.mod h1:GGzBIJMuE98Ic/kJsBXbz1x/7cByt++cQ+YOuDM5wus=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -146,6 +146,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 h1:TT4fX+nBOA/+LUkobKGW1ydGcn+G3vRw9+g5HwCphpk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0/go.mod h1:L7UH0GbB0p47T4Rri3uHjbpCFYrVrwc1I25QhNPiGK8=
 go.opentelemetry.io/otel v1.29.0 h1:PdomN/Al4q/lN6iBJEN3AwPvUiHPMlt93c8bqTG5Llw=
@@ -154,8 +156,6 @@ go.opentelemetry.io/otel/metric v1.29.0 h1:vPf/HFWTNkPu1aYeIsc98l4ktOQaL6LeSoeV2
 go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdgalxXqvp7BII/W8=
 go.opentelemetry.io/otel/trace v1.29.0 h1:J/8ZNK4XgR7a21DZUAsbF8pZ5Jcw1VhACmnYt39JTi4=
 go.opentelemetry.io/otel/trace v1.29.0/go.mod h1:eHl3w0sp3paPkYstJOmAimxhiFXPg+MMTlEh3nsQgWQ=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
@@ -173,8 +173,6 @@ golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
-golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
-golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
 golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/Jagerente/gocfg"
 	"github.com/Jagerente/gocfg/pkg/values"
+	"time"
 )
 
 type App struct {
@@ -38,11 +39,19 @@ type RedisConfig struct {
 }
 
 type Config struct {
-	App         App            `title:"App configuration"`
-	Logger      LoggerConfig   `title:"Logger configuration"`
-	Router      RouterConfig   `title:"Router configuration"`
-	RedisConfig RedisConfig    `title:"Redis configuration"`
-	Postgres    PostgresConfig `title:"Postgres configuration"`
+	App         App              `title:"App configuration"`
+	Logger      LoggerConfig     `title:"Logger configuration"`
+	Router      RouterConfig     `title:"Router configuration"`
+	RedisConfig RedisConfig      `title:"Redis configuration"`
+	Postgres    PostgresConfig   `title:"Postgres configuration"`
+	RateLimits  RateLimitsConfig `title:"Rate limits configuration"`
+}
+
+type RateLimitsConfig struct {
+	PostsLimit     uint64        `env:"POSTS_LIMIT" default:"30"`
+	PostsPeriod    time.Duration `env:"POSTS_PERIOD" default:"1h" description:"https://pkg.go.dev/time#ParseDuration"`
+	CommentsLimit  uint64        `env:"COMMENTS_LIMIT" default:"100"`
+	CommentsPeriod time.Duration `env:"COMMENTS_PERIOD" default:"30m" description:"https://pkg.go.dev/time#ParseDuration"`
 }
 
 func New() (*Config, error) {

--- a/internal/controller/echo/moderation.go
+++ b/internal/controller/echo/moderation.go
@@ -4,6 +4,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"net/http"
 	"workshop/internal/controller"
+	_ "workshop/internal/service/workshop"
+	_ "workshop/internal/types"
 )
 
 // ModeratePost godoc
@@ -50,8 +52,8 @@ func (c *PostHandler) ModeratePost(ctx echo.Context) error {
 //	@Tags			Moderation
 //	@Accept			json
 //	@Produce		json
-//	@Param			postID		query		types.PostID				false	"Post ID"
-//	@Param			moderatorID	query		types.UserID				false	"Moderator ID"
+//	@Param			postID		query		int							false	"Post ID"
+//	@Param			moderatorID	query		string						false	"Moderator ID"
 //	@Param			action		query		types.ModerationActionType	false	"Moderation action"
 //	@Param			sort_order	query		controller.SortOrder		false	"Sort order by creation time"			default(desc)
 //	@Param			page		query		int							true	"Page number"							minimum(1)

--- a/internal/controller/error.go
+++ b/internal/controller/error.go
@@ -1,6 +1,18 @@
 package controller
 
+import (
+	"github.com/labstack/echo/v4"
+	"time"
+)
+
 // APIError is echo.HTTPError wrapper for swagger generator
-type APIError struct {
-	Message string `json:"message"`
+type APIError echo.HTTPError
+
+type APIGenericError[T any] struct {
+	Message string `json:"message" extensions:"x-order=0"`
+	Data    T      `json:"data,omitempty" extensions:"x-order=1"`
+}
+
+type APIRateLimitErrorData struct {
+	ResetAt time.Time `json:"reset_at"`
 }

--- a/internal/service/workshop/config.go
+++ b/internal/service/workshop/config.go
@@ -1,0 +1,6 @@
+package workshop
+
+type Config struct {
+	PostsLimit    LimitConfig
+	CommentsLimit LimitConfig
+}

--- a/internal/service/workshop/errors.go
+++ b/internal/service/workshop/errors.go
@@ -1,6 +1,10 @@
 package workshop
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 var (
 	ErrPostNotFound        = errors.New("post not found")
@@ -11,6 +15,15 @@ var (
 
 	ErrCommentNotFound = errors.New("comment not found")
 	ErrCommentNotOwned = errors.New("comment not owned")
-
-	ErrLimitExceeded = errors.New("limit exceeded")
 )
+
+type RateLimitExceededError struct {
+	Info RateLimitInfo
+}
+
+func (e *RateLimitExceededError) Error() string {
+	return fmt.Sprintf(
+		"rate limit exceeded (limit=%d, current=%d, remaining=%d, resetAt=%s)",
+		e.Info.Limit, e.Info.Current, e.Info.Remaining, e.Info.ResetAt.Format(time.RFC3339),
+	)
+}

--- a/internal/service/workshop/limiter.go
+++ b/internal/service/workshop/limiter.go
@@ -1,0 +1,29 @@
+package workshop
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	PostsLimitKey    = "posts_limit"
+	CommentsLimitKey = "comments_limit"
+)
+
+type RateLimitInfo struct {
+	Limit     uint64
+	Current   uint64
+	Remaining uint64
+	ResetAt   time.Time
+}
+
+type LimitConfig struct {
+	Limit  uint64
+	Period time.Duration
+}
+
+type Limiter interface {
+	RegisterGroup(groupKey string, cfg LimitConfig)
+	Check(ctx context.Context, groupKey, userID string) (RateLimitInfo, error)
+	TriggerIncrease(ctx context.Context, groupKey, userID string) error
+}

--- a/internal/service/workshop/limiter/limiter.go
+++ b/internal/service/workshop/limiter/limiter.go
@@ -1,1 +1,0 @@
-package limiter

--- a/internal/service/workshop/limiter/redis.go
+++ b/internal/service/workshop/limiter/redis.go
@@ -1,0 +1,127 @@
+package limiter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/redis/go-redis/v9"
+	"sync"
+	"time"
+	"workshop/internal/service/workshop"
+)
+
+type RedisLimiter struct {
+	redisClient *redis.Client
+	keyPrefix   string
+
+	mu     sync.RWMutex
+	groups map[string]workshop.LimitConfig
+}
+
+func NewRedisLimiter(redisClient *redis.Client, keyPrefix string) *RedisLimiter {
+	return &RedisLimiter{
+		redisClient: redisClient,
+		keyPrefix:   keyPrefix,
+		groups:      make(map[string]workshop.LimitConfig),
+	}
+}
+
+func (r *RedisLimiter) RegisterGroup(groupKey string, cfg workshop.LimitConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.groups[groupKey] = cfg
+}
+
+func (r *RedisLimiter) getGroupConfig(groupKey string) workshop.LimitConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	cfg := r.groups[groupKey]
+	return cfg
+}
+
+func (r *RedisLimiter) Check(ctx context.Context, groupKey, userID string) (workshop.RateLimitInfo, error) {
+	cfg := r.getGroupConfig(groupKey)
+	if cfg.Limit == 0 {
+		return workshop.RateLimitInfo{
+			Limit:     cfg.Limit,
+			Current:   0,
+			Remaining: 1,
+			ResetAt:   time.Now().Add(cfg.Period),
+		}, nil
+	}
+
+	counterKey := r.buildKey(groupKey, userID)
+
+	pipe := r.redisClient.Pipeline()
+	getCmd := pipe.Get(ctx, counterKey)
+	ttlCmd := pipe.TTL(ctx, counterKey)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return workshop.RateLimitInfo{}, fmt.Errorf("redis pipeline exec error: %w", err)
+	}
+
+	current, err := getCmd.Uint64()
+	if errors.Is(err, redis.Nil) {
+		current = 0
+	} else if err != nil {
+		return workshop.RateLimitInfo{}, fmt.Errorf("failed GET in pipeline: %w", err)
+	}
+
+	ttl, err := ttlCmd.Result()
+	if err != nil {
+		return workshop.RateLimitInfo{}, fmt.Errorf("failed TTL in pipeline: %w", err)
+	}
+
+	if ttl <= 0 {
+		ttl = cfg.Period
+	}
+	resetAt := time.Now().Add(ttl)
+
+	var remaining uint64
+	if current >= cfg.Limit {
+		remaining = 0
+	} else {
+		remaining = cfg.Limit - current
+	}
+
+	return workshop.RateLimitInfo{
+		Limit:     cfg.Limit,
+		Current:   current,
+		Remaining: remaining,
+		ResetAt:   resetAt,
+	}, nil
+}
+
+func (r *RedisLimiter) TriggerIncrease(ctx context.Context, groupKey, userID string) error {
+	cfg := r.getGroupConfig(groupKey)
+	if cfg.Limit == 0 {
+		return nil
+	}
+
+	counterKey := r.buildKey(groupKey, userID)
+
+	pipe := r.redisClient.Pipeline()
+	incrCmd := pipe.Incr(ctx, counterKey)
+	ttlCmd := pipe.TTL(ctx, counterKey)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("pipeline exec error: %w", err)
+	}
+
+	newVal := incrCmd.Val()
+	ttl := ttlCmd.Val()
+
+	if (ttl <= 0) && (newVal == 1) {
+		if err := r.redisClient.Expire(ctx, counterKey, cfg.Period).Err(); err != nil {
+			return fmt.Errorf("failed to set expire: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *RedisLimiter) buildKey(groupKey, userID string) string {
+	return fmt.Sprintf("%s:%s:%s", r.keyPrefix, groupKey, userID)
+}

--- a/internal/service/workshop/limiter/redis_test.go
+++ b/internal/service/workshop/limiter/redis_test.go
@@ -1,0 +1,291 @@
+package limiter
+
+import (
+	"context"
+	"github.com/alicebob/miniredis/v2"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"workshop/internal/service/workshop"
+)
+
+func Test_NewRedisLimiter(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+
+	rl := NewRedisLimiter(client, "test_prefix")
+	require.NotNil(t, rl)
+	assert.Equal(t, "test_prefix", rl.keyPrefix)
+	assert.NotNil(t, rl.groups)
+	assert.Equal(t, 0, len(rl.groups))
+}
+
+func Test_RedisLimiter_RegisterGroup(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+
+	rl := NewRedisLimiter(client, "test_prefix")
+	cfg := workshop.LimitConfig{
+		Limit:  10,
+		Period: 5 * time.Minute,
+	}
+	rl.RegisterGroup("posts_limit", cfg)
+
+	require.Equal(t, 1, len(rl.groups))
+	storedCfg := rl.getGroupConfig("posts_limit")
+	assert.Equal(t, uint64(10), storedCfg.Limit)
+	assert.Equal(t, 5*time.Minute, storedCfg.Period)
+}
+
+func Test_RedisLimiter_Check(t *testing.T) {
+	t.Run("Check with non-existent key", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  3,
+			Period: 2 * time.Minute,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		info, err := rl.Check(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(3), info.Limit)
+		assert.Equal(t, uint64(0), info.Current)
+		assert.Equal(t, uint64(3), info.Remaining)
+		assert.True(t, time.Until(info.ResetAt) <= 2*time.Minute+time.Second)
+	})
+
+	t.Run("Check with existent key", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  5,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		err = client.Set(context.Background(), "prefix:test_group:user123", 2, 0).Err()
+		require.NoError(t, err)
+		err = client.Expire(context.Background(), "prefix:test_group:user123", 10*time.Minute).Err()
+		require.NoError(t, err)
+
+		info, err := rl.Check(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), info.Limit)
+		assert.Equal(t, uint64(2), info.Current)
+		assert.Equal(t, uint64(3), info.Remaining)
+		assert.True(t, time.Until(info.ResetAt) <= 10*time.Minute+time.Second)
+	})
+
+	t.Run("Corrupted counter value", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  5,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		err = client.Set(context.Background(), "prefix:test_group:user123", "not-a-number", 0).Err()
+		require.NoError(t, err)
+
+		_, checkErr := rl.Check(context.Background(), "test_group", "user123")
+		assert.ErrorIs(t, checkErr, strconv.ErrSyntax)
+	})
+
+	t.Run("Zero limit config", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  0,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("zero_group", cfg)
+
+		info, err := rl.Check(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), info.Limit)
+		assert.Equal(t, uint64(0), info.Current)
+		assert.Equal(t, uint64(1), info.Remaining)
+	})
+
+	t.Run("Pipeline exec error", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  2,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		mr.Close()
+
+		_, checkErr := rl.Check(context.Background(), "test_group", "user123")
+		assert.Error(t, checkErr)
+		assert.Contains(t, checkErr.Error(), "pipeline exec error")
+	})
+}
+
+func Test_RedisLimiter_TriggerIncrease(t *testing.T) {
+	t.Run("Key does not exist", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  5,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		err = rl.TriggerIncrease(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+
+		valStr, err := client.Get(context.Background(), "prefix:test_group:user123").Result()
+		require.NoError(t, err)
+		val, err := strconv.Atoi(valStr)
+		require.NoError(t, err)
+		assert.Equal(t, 1, val)
+
+		ttl, err := client.TTL(context.Background(), "prefix:test_group:user123").Result()
+		require.NoError(t, err)
+		assert.True(t, ttl > 0)
+	})
+
+	t.Run("Key exists and leaves TTL if > 0", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  5,
+			Period: 10 * time.Minute,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		err = client.Set(context.Background(), "prefix:test_group:user123", 2, 5*time.Minute).Err()
+		require.NoError(t, err)
+
+		err = rl.TriggerIncrease(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+
+		valStr, err := client.Get(context.Background(), "prefix:test_group:user123").Result()
+		require.NoError(t, err)
+		val, err := strconv.Atoi(valStr)
+		require.NoError(t, err)
+		assert.Equal(t, 3, val)
+
+		ttl, err := client.TTL(context.Background(), "prefix:test_group:user123").Result()
+		require.NoError(t, err)
+		assert.True(t, ttl > 4*time.Minute && ttl <= 5*time.Minute)
+	})
+
+	t.Run("Zero limit config", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+		defer mr.Close()
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  0,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		err = rl.TriggerIncrease(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+		err = rl.TriggerIncrease(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+
+		_, err = client.Get(context.Background(), "prefix:zero_group:user_zero").Result()
+		assert.Error(t, err)
+
+		info, err := rl.Check(context.Background(), "test_group", "user123")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), info.Current)
+		assert.Equal(t, uint64(1), info.Remaining)
+	})
+
+	t.Run("Pipeline exec error", func(t *testing.T) {
+		mr, err := miniredis.Run()
+		require.NoError(t, err)
+
+		client := redis.NewClient(&redis.Options{
+			Addr: mr.Addr(),
+		})
+
+		rl := NewRedisLimiter(client, "prefix")
+		cfg := workshop.LimitConfig{
+			Limit:  5,
+			Period: 1 * time.Hour,
+		}
+		rl.RegisterGroup("test_group", cfg)
+
+		mr.Close()
+
+		err = rl.TriggerIncrease(context.Background(), "test_group", "user123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "pipeline exec error")
+	})
+}


### PR DESCRIPTION
- Added rate limiting for Create Post and Add Comment actions per user.
  - Configurable amount and reset duration through config.
  - Reset timer starts from first item created without active limit timer.
  - To remove rate limiting - set amount limit value to 0.
  - Redis as driver.
- Updated API responses.
  - Response code 429 with reset period data for endpoints:
    - `{{baseUrl}}/posts`
    - `{{baseUrl}}/comments`
- Updated app configuration

```
# Posts per period per user allowed
POSTS_LIMIT=30

# Posts limit reset period duration
# Value patterns - https://pkg.go.dev/time#ParseDuration
POSTS_PERIOD=1h

# Posts per period per user allowed
COMMENTS_LIMIT=100

# Comments limit reset period duration
#  Value patterns - https://pkg.go.dev/time#ParseDuration
COMMENTS_PERIOD=30m
```